### PR TITLE
Add very basic/buggy Magento module to load bundles

### DIFF
--- a/Magento_BundleConfig/Block/Html/Head/Config.php
+++ b/Magento_BundleConfig/Block/Html/Head/Config.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\BundleConfig\Block\Html\Head;
+
+use Magento\Framework\RequireJs\Config as RequireJsConfig;
+use Magento\Framework\View\Asset\Minification;
+
+class Config extends \Magento\Framework\View\Element\AbstractBlock
+{
+    /**
+     * @var RequireJsConfig
+     */
+    private $config;
+
+    /**
+     * @var \Magento\RequireJs\Model\FileManager
+     */
+    private $fileManager;
+
+    /**
+     * @var \Magento\Framework\View\Page\Config
+     */
+    protected $pageConfig;
+
+    /**
+     * @var \Magento\Framework\View\Asset\ConfigInterface
+     */
+    private $bundleConfig;
+
+    /**
+     * @param \Magento\Framework\View\Element\Context $context
+     * @param RequireJsConfig $config
+     * @param \Magento\BundleConfig\Model\FileManager $fileManager
+     * @param \Magento\Framework\View\Page\Config $pageConfig
+     * @param \Magento\Framework\View\Asset\ConfigInterface $bundleConfig
+     * @param array $data
+     */
+    public function __construct(
+        \Magento\Framework\View\Element\Context $context,
+        RequireJsConfig $config,
+        \Magento\BundleConfig\Model\FileManager $fileManager,
+        \Magento\Framework\View\Page\Config $pageConfig,
+        \Magento\Framework\View\Asset\ConfigInterface $bundleConfig,
+        array $data = []
+    ) {
+        $this->fileManager = $fileManager;
+        $this->pageConfig = $pageConfig;
+        parent::__construct($context, $data);
+    }
+
+    /**
+     * Include specified AMD bundle as an asset on the page
+     *
+     * @return $this
+     */
+    protected function _prepareLayout()
+    {
+        $fullActionName = $this->getRequest()->getFullActionName();
+        $assetCollection = $this->pageConfig->getAssetCollection();
+        $bundleConfig = $this->fileManager->createJsBundleAsset($fullActionName);
+        $assetCollection->insert(
+            $bundleConfig->getFilePath(),
+            $bundleConfig,
+            RequireJsConfig::REQUIRE_JS_FILE_NAME
+        );
+
+        $shared = $this->fileManager->createSharedJsBundleAsset();
+        $assetCollection->insert(
+            $shared->getFilePath(),
+            $shared,
+            $bundleConfig->getFilePath()
+        );
+
+        return parent::_prepareLayout();
+    }
+}

--- a/Magento_BundleConfig/Model/FileManager.php
+++ b/Magento_BundleConfig/Model/FileManager.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\BundleConfig\Model;
+
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\State as AppState;
+use Magento\Framework\RequireJs\Config;
+
+class FileManager
+{
+    /**
+     * @var \Magento\Framework\View\Asset\Repository
+     */
+    private $assetRepo;
+
+    /**
+     * @param \Magento\Framework\View\Asset\Repository $assetRepo
+     */
+    public function __construct(
+        \Magento\Framework\View\Asset\Repository $assetRepo
+    ) {
+        $this->assetRepo = $assetRepo;
+        $this->staticContext = $assetRepo->getStaticViewFileContext();
+    }
+
+    /**
+     * Create a view asset representing the JS bundle for the page
+     *
+     * @return \Magento\Framework\View\Asset\File
+     */
+    public function createJsBundleAsset($fullActionName)
+    {
+        // TODO: Just generate paths with underscores in the Chrome extension
+        $formattedActionName = str_replace("_", "-", $fullActionName);
+        $relPath = $this->staticContext->getConfigPath() . '/bundles/' . $formattedActionName . '.js';
+        // TODO: Find a way to silently bail when file does not exist. Not all action's
+        // handles will have an associated JS bundle
+        return $this->assetRepo->createArbitrary($relPath, '');
+    }
+
+    public function createSharedJsBundleAsset()
+    {
+        $relPath = $this->staticContext->getConfigPath() . '/bundles/shared.js';
+        return $this->assetRepo->createArbitrary($relPath, '');
+    }
+}

--- a/Magento_BundleConfig/etc/module.xml
+++ b/Magento_BundleConfig/etc/module.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Magento_BundleConfig">
+        <sequence>
+            <!-- TODO: Figure out which dependencies we actually need -->
+            <module name="Magento_Catalog"/>
+        </sequence>
+    </module>
+</config>

--- a/Magento_BundleConfig/registration.php
+++ b/Magento_BundleConfig/registration.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+use \Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(ComponentRegistrar::MODULE, 'Magento_BundleConfig', __DIR__);

--- a/Magento_BundleConfig/view/frontend/layout/default.xml
+++ b/Magento_BundleConfig/view/frontend/layout/default.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="default_head_blocks"/>
+    <body>
+        <referenceContainer name="after.body.start">
+            <block class="Magento\BundleConfig\Block\Html\Head\Config" name="bundle-config" before="requirejs-config"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/Magento_BundleConfig/view/frontend/requirejs-config.js
+++ b/Magento_BundleConfig/view/frontend/requirejs-config.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+var config = {
+    deps: ['jquery/jquery.cookie'],
+};


### PR DESCRIPTION
## This PR is a:

[ ] New feature
[X] Enhancement/Optimization
[ ] Refactor
[ ] Bugfix
[ ] Test for existing code
[ ] Documentation

## Summary

When this pull request is merged, it will add a Magento module that loads matching page-specific bundles at runtime. The code is mostly copy/pasted from the `Magento_RequireJs` module, and does not adhere to m2 best practices.

## Additional information
