### PR TITLE
Run TypeScript compiler in CI, and drastically speed up licenseHeaderCheck.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Helpful in-browser tooling for Magento 2",
   "license": "SEE LICENSE IN LICENSE",
   "scripts": {
-    "test": "npm run format:check && npm run license:check && jest",
+    "test": "npm run format:check && npm run license:check && tsc && jest",
     "test:dev": "jest --watch",
     "build": "webpack",
     "start": "webpack --watch",

--- a/scripts/licenseHeaderCheck.js
+++ b/scripts/licenseHeaderCheck.js
@@ -13,7 +13,7 @@ const readFilePromise = promisify(readFile);
 
 (async () => {
     const filePaths = await globPromise('**/*.{js,ts,html}', {
-        ignore: ['node_modules/**/*', 'extension/dist/**/*'],
+        ignore: ['node_modules/**', 'extension/dist/**'],
     });
 
     const missingHeaders = (await Promise.all(


### PR DESCRIPTION
## This PR is a:

- [ ] New feature
- [X] Enhancement/Optimization
- [ ] Refactor
- [ ] Bugfix
- [ ] Test for existing code
- [ ] Documentation

## Summary

When this pull request is merged, it will run TypeScript in CI to prevent failed builds making it to `master`
