### PR TITLE
Adding unit tests for bundle generation. Closes #2

### DIFF
--- a/src/RequireJS/BundleGenerator/__tests__/generate.test.ts
+++ b/src/RequireJS/BundleGenerator/__tests__/generate.test.ts
@@ -4,8 +4,9 @@
  */
 
 import generate, { RequireModule } from '../generate';
+import { RequireConfig } from '../../../types/require';
 
-const sampleRequireConfig = {
+const sampleRequireConfig: RequireConfig = {
     baseUrl: 'http://website.com',
     map: {
         '*': {},
@@ -18,7 +19,7 @@ const modulesByName = (modules: RequireModule[]) =>
         return (acc[cur.name] = cur), acc;
     }, {});
 
-test('Simple usage 1', () => {
+test('Splits common modules out, keeping uniques', () => {
     const modulesByPageType = [
         {
             url: 'http://www.site.com',
@@ -44,4 +45,111 @@ test('Simple usage 1', () => {
         'product/foo',
         'product/bar',
     ]);
+});
+
+test('Sets URLs in paths and map* config to empty', () => {
+    const modulesByPageType = [
+        {
+            url: 'http://www.site.com',
+            pageConfigType: 'cms-index-index',
+            modules: ['home/foo', 'home/bar', 'common/one'],
+        },
+    ];
+    const requireConfig = {
+        ...sampleRequireConfig,
+        paths: {
+            foo: 'https://www.cdn.com/foo.js',
+        },
+        map: {
+            '*': {
+                bar: 'https://www.cdn.com/bar.js',
+            },
+        },
+    };
+
+    const { paths, map } = generate(modulesByPageType, requireConfig);
+    expect(paths.foo).toBe('empty:');
+    expect(map['*'].bar).toBe('empty:');
+});
+
+// https://github.com/requirejs/example-multipage/blob/3aae13210720e6b02e69513431bdf6a1fa516556/tools/build.js#L20-L24
+test('Shared bundle is first, to ensure later excludes of it work', () => {
+    const modulesByPageType = [
+        {
+            url: 'http://www.site.com',
+            pageConfigType: 'cms-index-index',
+            modules: ['home/foo', 'home/bar', 'common/one'],
+        },
+        {
+            url: 'http://www.site.com/some-product',
+            pageConfigType: 'catalog-product-view',
+            modules: ['product/foo', 'common/one', 'product/bar'],
+        },
+    ];
+
+    const { modules } = generate(modulesByPageType, sampleRequireConfig);
+    expect(modules[0].name).toBe('bundles/shared');
+});
+
+test('Does not create bundle for handles with no unique modules', () => {
+    const modulesByPageType = [
+        {
+            url: 'http://www.site.com',
+            pageConfigType: 'cms-index-index',
+            modules: ['common/one'],
+        },
+        {
+            url: 'http://www.site.com/some-product',
+            pageConfigType: 'catalog-product-view',
+            modules: ['product/foo', 'common/one'],
+        },
+    ];
+
+    const { modules } = generate(modulesByPageType, sampleRequireConfig);
+    const byName = modulesByName(modules);
+    expect(byName).not.toHaveProperty('bundles/cms-index-index');
+});
+
+test('Fixes "text" mapping in paths for r.js', () => {
+    const modulesByPageType = [
+        {
+            url: 'http://www.site.com',
+            pageConfigType: 'cms-index-index',
+            modules: ['home/foo', 'home/bar', 'common/one'],
+        },
+    ];
+    const requireConfig = {
+        ...sampleRequireConfig,
+        paths: {
+            text: 'mage/requirejs/text',
+        },
+    };
+
+    const { paths } = generate(modulesByPageType, requireConfig);
+    expect(paths.text).toBe('requirejs/text');
+});
+
+test('Provided paths and map* are included in generated config', () => {
+    const modulesByPageType = [
+        {
+            url: 'http://www.site.com',
+            pageConfigType: 'cms-index-index',
+            modules: ['home/foo', 'home/bar', 'common/one'],
+        },
+    ];
+    const requireConfig = {
+        ...sampleRequireConfig,
+        paths: {
+            testFoo: 'test/foo',
+        },
+        map: {
+            '*': {
+                testBar: 'test/bar',
+            },
+        },
+    };
+
+    const { paths, map } = generate(modulesByPageType, requireConfig);
+    expect(paths.testFoo).toBe('test/foo');
+    expect(map['*'].testBar).toBe('test/bar');
 });

--- a/src/RequireJS/BundleGenerator/generate.ts
+++ b/src/RequireJS/BundleGenerator/generate.ts
@@ -19,7 +19,7 @@ export type RequireModule = {
 };
 
 type BundleConfig = {
-    optimize: 'none';
+    optimize: 'none' | 'uglify2';
     wrapShim: boolean;
     modules: RequireModule[];
     inlineText: boolean;
@@ -115,7 +115,7 @@ export default function generate(
         .reverse();
 
     return {
-        optimize: 'none',
+        optimize: 'uglify2',
         wrapShim: true,
         inlineText: true,
         modules: finalModules,


### PR DESCRIPTION
## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [ ] Bugfix
- [X] Test for existing code
- [ ] Documentation

## Summary

When this pull request is merged, it will add coverage for [`generate.ts`](https://github.com/magento/m2-devtools/blob/c2f32bd5e3ecb83adf1bd288f3bc248608f0e901/src/RequireJS/BundleGenerator/generate.ts), so that I can feel comfortable refactoring that mess 😆.

