### PR TITLE
Extracted page scraping loop from react component to separate module and added unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@
 
 module.exports = {
     preset: 'ts-jest',
-    testEnvironment: 'node',
+    testEnvironment: 'jsdom',
     setupFiles: [
         // v8 with built-in flat (v6.9.x) won't be in node until v11.
         // Do not remove this polyfill until node 12 is LTS

--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -60,6 +60,7 @@ export default class App extends React.Component<{}, State> {
                         // each tab to persist its state without having to hoist
                         // state to the root of the tree
                         <div
+                            key={panel.title}
                             className={styles.rightPanelItemWrapper}
                             data-selected={panel === selectedPanel}
                         >

--- a/src/RequireJS/BundleGenerator/ConfigGen.tsx
+++ b/src/RequireJS/BundleGenerator/ConfigGen.tsx
@@ -4,18 +4,18 @@
  */
 
 import * as React from 'react';
-import { RequireConfig, ModulesByPageType } from '../../types/require';
+import { RequireConfig, PageModule } from '../../types/require';
 import generate from './generate';
 
 type Props = {
-    modulesByPageType: ModulesByPageType;
+    pageModules: PageModule[];
     requireConfig: RequireConfig;
 };
 
 export default class ConfigGen extends React.Component<Props> {
     render() {
-        const { modulesByPageType, requireConfig } = this.props;
-        const config = generate(modulesByPageType, requireConfig);
+        const { pageModules, requireConfig } = this.props;
+        const config = generate(pageModules, requireConfig);
 
         return <pre>{JSON.stringify(config, null, 2)}</pre>;
     }

--- a/src/RequireJS/BundleGenerator/PageCollector.ts
+++ b/src/RequireJS/BundleGenerator/PageCollector.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import { PageModule, RequireConfig } from '../../types/require';
+import { getBundlingData } from '../../interop';
+
+type CollectVal = {
+    config: RequireConfig;
+    page: PageModule;
+};
+type Callback = (data: CollectVal) => void;
+
+export default class PageCollector {
+    timerID: number | null = null;
+    private listeners: Set<Callback> = new Set();
+
+    private pollForModules() {
+        this.timerID = window.setTimeout(async () => {
+            try {
+                const {
+                    modules,
+                    config,
+                    pageConfigType,
+                    url,
+                } = await getBundlingData();
+
+                // TODO: Actually handle this case, since it will point to a bug
+                // in the shaky logic of `_getPageConfigType` in `interop.ts`
+                if (!pageConfigType) throw new Error('No pageConfigType found');
+
+                const page = {
+                    url,
+                    pageConfigType,
+                    // TODO: Address this hack better. m2 has a bug where
+                    // a superfluous mixin is added to the Require registry for any
+                    // require() with a relative URL (./).
+                    modules: modules.filter(m => !m.startsWith('mixins!')),
+                };
+
+                this.notifyListeners({ page, config });
+            } catch (err) {
+                // TODO: Handle errors. Most common error is us attempting
+                // to eval code in the currently-inspected page when it's
+                // between pages, which can be safely ignored
+            }
+
+            this.pollForModules();
+        }, 200);
+    }
+
+    private notifyListeners(val: CollectVal) {
+        this.listeners.forEach(f => f(val));
+    }
+
+    private stopPolling() {
+        if (this.timerID) window.clearTimeout(this.timerID);
+    }
+
+    unsubscribe(cb: Callback) {
+        this.listeners.delete(cb);
+        if (!this.listeners.size) this.stopPolling();
+    }
+
+    subscribe(cb: Callback) {
+        this.listeners.add(cb);
+        if (this.listeners.size === 1) this.pollForModules();
+    }
+}

--- a/src/RequireJS/BundleGenerator/RecordingProgress.tsx
+++ b/src/RequireJS/BundleGenerator/RecordingProgress.tsx
@@ -4,21 +4,21 @@
  */
 
 import * as React from 'react';
-import { ModulesByPageType, PageModule } from '../../types/require';
+import { ModulesByURL, PageModule } from '../../types/require';
 import styles from './RecordingProgress.css';
 
 type Props = {
-    modulesByPageType: ModulesByPageType;
+    modulesByURL: ModulesByURL;
 };
 
 export default class RecordingProgress extends React.Component<Props> {
     render() {
-        const { modulesByPageType } = this.props;
+        const { modulesByURL } = this.props;
 
         return (
             <div className={styles.wrapper}>
                 <ul className={styles.pageList}>
-                    {modulesByPageType.map(mod => (
+                    {Object.values(modulesByURL).map(mod => (
                         <PageTypeTile key={mod.url} mod={mod} />
                     ))}
                 </ul>

--- a/src/RequireJS/BundleGenerator/__tests__/PageCollector.test.ts
+++ b/src/RequireJS/BundleGenerator/__tests__/PageCollector.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import PageCollector from '../PageCollector';
+import { getBundlingData } from '../../../interop';
+
+jest.mock('../../../interop');
+jest.useFakeTimers();
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+});
+
+test('Does not start polling until a subscription exists', () => {
+    const collector = new PageCollector();
+    jest.runAllTimers();
+    expect(getBundlingData).not.toHaveBeenCalled();
+
+    const subscriber = jest.fn();
+    collector.subscribe(subscriber);
+    jest.runAllTimers();
+
+    expect(getBundlingData).toHaveBeenCalled();
+});
+
+test('Stops notifying subscriber when it is unsubscribed', () => {
+    const collector = new PageCollector();
+    const subscriber = jest.fn();
+    collector.subscribe(subscriber);
+
+    jest.runAllTimers();
+    const callCountBeforeUnsubscribe = subscriber.mock.calls.length;
+    collector.unsubscribe(subscriber);
+    jest.runAllTimers();
+
+    expect(subscriber).toHaveBeenCalledTimes(callCountBeforeUnsubscribe);
+});
+
+test('Removes modules that are prepended with "mixins!"', () => {
+    const mock = (getBundlingData as unknown) as jest.MockInstance<
+        typeof getBundlingData
+    >;
+    mock.mockReturnValue(
+        Promise.resolve({
+            url: 'https://www.site.com/product',
+            config: {},
+            pageConfigType: 'catalog-product-view',
+            modules: ['foo', 'bar', 'mixins!bar', 'bizz'],
+        }),
+    );
+
+    const collector = new PageCollector();
+    const subscriber = jest.fn();
+    collector.subscribe(subscriber);
+
+    jest.runAllTimers();
+
+    // Unlike tests using the `jest.mock` automock functionality,
+    // we need to wait briefly here because the Promise passed to `mock.mockReturnValue`
+    // above uses a microtask to unwrap
+    setImmediate(() => {
+        expect(subscriber).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/RequireJS/BundleGenerator/generate.ts
+++ b/src/RequireJS/BundleGenerator/generate.ts
@@ -3,11 +3,7 @@
  * See COPYING.txt for license details.
  */
 
-import {
-    ModulesByPageType,
-    ShimConfig,
-    RequireConfig,
-} from '../../types/require';
+import { ShimConfig, RequireConfig, PageModule } from '../../types/require';
 import intersection from 'lodash.intersection';
 import difference from 'lodash.difference';
 
@@ -35,13 +31,11 @@ type BundleConfig = {
 };
 
 export default function generate(
-    modulesByPageType: ModulesByPageType,
+    pageModules: PageModule[],
     requireConfig: RequireConfig,
 ): BundleConfig {
     // Cheap clone so we can feel free to mutate
-    const modules = JSON.parse(
-        JSON.stringify(modulesByPageType),
-    ) as ModulesByPageType;
+    const modules = JSON.parse(JSON.stringify(pageModules)) as PageModule[];
 
     const commons: string[] = [];
     modules.forEach(mod => {

--- a/src/RequireJS/index.tsx
+++ b/src/RequireJS/index.tsx
@@ -46,6 +46,7 @@ export default class RequireJS extends React.Component<{}, State> {
                 />
                 {tabs.map(tab => (
                     <div
+                        key={tab.name}
                         className={styles.tabWrapper}
                         data-selected={tab === selectedTab}
                     >

--- a/src/interop.ts
+++ b/src/interop.ts
@@ -95,6 +95,16 @@ function _getURL(): string {
 }
 export const getURL = () => evalInPage<string>(_getURL.toString());
 
+export async function getBundlingData() {
+    const [modules, config, pageConfigType, url] = await Promise.all([
+        getLoadedModules(),
+        getRequireConfig(),
+        getPageConfigType(),
+        getURL(),
+    ]);
+    return { modules, config, pageConfigType, url };
+}
+
 function evalInPage<T>(code: string): Promise<T> {
     return new Promise((res, rej) => {
         const wrappedCode = `(${code})()`;

--- a/src/types/require.ts
+++ b/src/types/require.ts
@@ -29,7 +29,9 @@ export type PageModule = {
     modules: string[];
 };
 
-export type ModulesByPageType = PageModule[];
+export type ModulesByURL = {
+    [key: string]: PageModule;
+};
 
 export type ShimConfig = {
     [key: string]:


### PR DESCRIPTION
## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [X] Refactor
- [ ] Bugfix
- [ ] Test for existing code
- [ ] Documentation

## Summary

This PR includes the following changes:

1. Logic for polling and scraping the page for modules has been extracted from the `BundleGenerator/index.tsx` module into its own isolated module, with tests. `BundleGenerator/index.tsx` is now a subscriber
2. Refactored types a bit to prep for tracking multiple distinct pages with the same layout handle
3. Fixed some React warnings for missing `key` prop in collections
