### PR TITLE
Add Magento_BundleConfig to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 extension/
 package.json
 package-lock.json
+Magento_BundleConfig

--- a/Magento_BundleConfig/view/frontend/requirejs-config.js
+++ b/Magento_BundleConfig/view/frontend/requirejs-config.js
@@ -4,5 +4,5 @@
  */
 
 var config = {
-    deps: ['jquery/jquery.cookie'],
+    deps: ['jquery/jquery.cookie']
 };


### PR DESCRIPTION
Because trailing commas in runtime JS will break IE11