### PR TITLE
Backward compatibility and PHP cleanup

### DIFF
--- a/Magento_BundleConfig/Block/Html/Head/Config.php
+++ b/Magento_BundleConfig/Block/Html/Head/Config.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.

--- a/Magento_BundleConfig/Block/Html/Head/Config.php
+++ b/Magento_BundleConfig/Block/Html/Head/Config.php
@@ -7,6 +7,7 @@
 namespace Magento\BundleConfig\Block\Html\Head;
 
 use Magento\BundleConfig\Model\FileManager as BundleFileManager;
+use Magento\Framework\App\Request\Http as HttpRequest;
 use Magento\Framework\Filesystem\DirectoryList;
 use Magento\Framework\RequireJs\Config as RequireJsConfig;
 use Magento\Framework\App\State as AppState;
@@ -37,6 +38,11 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
     private $dir;
 
     /**
+     * @var HttpRequest
+     */
+    private $httpRequest;
+
+    /**
      * @param ViewElementContext $context
      * @param AppState $appState
      * @param BundleFileManager $fileManager
@@ -49,6 +55,7 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
         BundleFileManager $fileManager,
         PageConfig $pageConfig,
         DirectoryList $dir,
+        HttpRequest $httpRequest,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -56,6 +63,7 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
         $this->pageConfig = $pageConfig;
         $this->appState = $appState;
         $this->dir = $dir;
+        $this->httpRequest = $httpRequest;
     }
 
     /**
@@ -70,7 +78,7 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
         }
 
         $staticDir = $this->dir->getPath('static');
-        $fullActionName = $this->getRequest()->getFullActionName();
+        $fullActionName = $this->httpRequest->getFullActionName();
 
         $assetCollection = $this->pageConfig->getAssetCollection();
 

--- a/Magento_BundleConfig/Block/Html/Head/Config.php
+++ b/Magento_BundleConfig/Block/Html/Head/Config.php
@@ -6,48 +6,49 @@
 
 namespace Magento\BundleConfig\Block\Html\Head;
 
+use Magento\BundleConfig\Model\FileManager as BundleFileManager;
+use Magento\Framework\Filesystem\DirectoryList;
 use Magento\Framework\RequireJs\Config as RequireJsConfig;
 use Magento\Framework\App\State as AppState;
+use Magento\Framework\View\Element\Context as ViewElementContext;
+use Magento\Framework\View\Page\Config as PageConfig;
+use Magento\RequireJs\Model\FileManager;
 
 class Config extends \Magento\Framework\View\Element\AbstractBlock
 {
     /**
-     * @var RequireJsConfig
-     */
-    private $config;
-
-    /**
-     * @var \Magento\RequireJs\Model\FileManager
+     * @var FileManager
      */
     private $fileManager;
 
     /**
-     * @var \Magento\Framework\View\Page\Config
+     * @var PageConfig
      */
-    protected $pageConfig;
+    private $pageConfig;
 
     /**
-     * @var \Magento\Framework\View\Asset\ConfigInterface
+     * @var AppState 
      */
-    private $bundleConfig;
+    private $appState;
 
     /**
-     * @param \Magento\Framework\View\Element\Context $context
-     * @param RequireJsConfig $config
+     * @var DirectoryList
+     */
+    private $dir;
+
+    /**
+     * @param ViewElementContext $context
      * @param AppState $appState
-     * @param \Magento\BundleConfig\Model\FileManager $fileManager
-     * @param \Magento\Framework\View\Page\Config $pageConfig
-     * @param \Magento\Framework\View\Asset\ConfigInterface $bundleConfig
+     * @param BundleFileManager $fileManager
+     * @param PageConfig $pageConfig
      * @param array $data
      */
     public function __construct(
-        \Magento\Framework\View\Element\Context $context,
-        RequireJsConfig $config,
+        ViewElementContext $context,
         AppState $appState,
-        \Magento\BundleConfig\Model\FileManager $fileManager,
-        \Magento\Framework\View\Page\Config $pageConfig,
-        \Magento\Framework\View\Asset\ConfigInterface $bundleConfig,
-        \Magento\Framework\Filesystem\DirectoryList $dir,
+        BundleFileManager $fileManager,
+        PageConfig $pageConfig,
+        DirectoryList $dir,
         array $data = []
     ) {
         parent::__construct($context, $data);
@@ -60,11 +61,11 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
     /**
      * Include specified AMD bundle as an asset on the page
      *
-     * @return $this
+     * @return \Magento\Framework\View\Element\AbstractBlock
      */
     protected function _prepareLayout()
     {
-        if ($this->appState->getMode() == AppState::MODE_DEVELOPER) {
+        if ($this->appState->getMode() === AppState::MODE_DEVELOPER) {
             return parent::_prepareLayout();
         }
 

--- a/Magento_BundleConfig/Block/Html/Head/Config.php
+++ b/Magento_BundleConfig/Block/Html/Head/Config.php
@@ -8,7 +8,6 @@ namespace Magento\BundleConfig\Block\Html\Head;
 
 use Magento\Framework\RequireJs\Config as RequireJsConfig;
 use Magento\Framework\App\State as AppState;
-use Magento\Framework\View\Asset\Minification;
 
 class Config extends \Magento\Framework\View\Element\AbstractBlock
 {

--- a/Magento_BundleConfig/Model/FileManager.php
+++ b/Magento_BundleConfig/Model/FileManager.php
@@ -1,27 +1,30 @@
-<?php
+<?php declare(strict_types=1);
 /**
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
 namespace Magento\BundleConfig\Model;
 
-use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\App\State as AppState;
-use Magento\Framework\RequireJs\Config;
+use Magento\Framework\View\Asset\File\FallbackContext as FileFallbackContext;
+use Magento\Framework\View\Asset\Repository as AssetRepository;
 
 class FileManager
 {
     /**
-     * @var \Magento\Framework\View\Asset\Repository
+     * @var AssetRepository
      */
     private $assetRepo;
 
     /**
-     * @param \Magento\Framework\View\Asset\Repository $assetRepo
+     * @var FileFallbackContext 
      */
-    public function __construct(
-        \Magento\Framework\View\Asset\Repository $assetRepo
-    ) {
+    private $staticContext;
+
+    /**
+     * @param AssetRepository $assetRepo
+     */
+    public function __construct(AssetRepository $assetRepo)
+    {
         $this->assetRepo = $assetRepo;
         $this->staticContext = $assetRepo->getStaticViewFileContext();
     }

--- a/Magento_BundleConfig/etc/module.xml
+++ b/Magento_BundleConfig/etc/module.xml
@@ -6,7 +6,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Magento_BundleConfig">
+    <module name="Magento_BundleConfig" setup_version="0.0.1">
         <sequence>
             <module name="Magento_RequireJs"/>
         </sequence>


### PR DESCRIPTION
## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [x] Refactor
- [ ] Bugfix
- [ ] Test for existing code
- [ ] Documentation

## Summary

When this pull request is merged, it will make the module backward compatible with Magento 2.1 and 2.2 by supplying a `setup_version` in the `etc/module.xml` file.  

Besides this it mainly removes unused imports, adds undeclared fields and adds imports and nicer aliases for classes that where used with the fully qualified class name.

Finally it also removes an interface violation where the method `getFullActionName()` was called on the interface `\Magento\Framework\App\RequestInterface` when it only exists on the implementation `\Magento\Framework\App\Request\Http`.

Related Issue #7 