### PR TITLE
Force white background for dark themes

### DIFF
--- a/src/App/App.css
+++ b/src/App/App.css
@@ -5,6 +5,7 @@
 
 .wrapper {
     display: flex;
+    background-color: #fff;
 }
 
 .rightPanelItemWrapper[data-selected='false'] {


### PR DESCRIPTION
## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [X ] Bugfix
- [ ] Test for existing code
- [ ] Documentation

## Summary

When this pull request is merged, it will allow Chrome dark themes to still use the UI.

## Additional information

The extension has no global background-color which means when using Chrome's dark theme in devtools, the extension is unreadable:

![screen shot 2018-12-11 at 2 57 00 pm](https://user-images.githubusercontent.com/3484527/49826523-17e91980-fd55-11e8-846f-c03eeee40526.png)

This adds a white background so that it's still possible to read:

![screen shot 2018-12-11 at 2 56 15 pm](https://user-images.githubusercontent.com/3484527/49826537-21728180-fd55-11e8-9e3d-b9e91e3b23be.png)
