### PR TITLE
#47: Disable minification of JS assest when BundleConfig module enabled

### DIFF
--- a/Magento_BundleConfig/Plugin/View/Asset/MinificationPlugin.php
+++ b/Magento_BundleConfig/Plugin/View/Asset/MinificationPlugin.php
@@ -1,0 +1,29 @@
+<?php
+namespace Magento\BundleConfig\Plugin\View\Asset;
+
+/**
+ * Class MinificationPlugin
+ * @package Magento\BundleConfig\Plugin\View\Asset
+ */
+class MinificationPlugin
+{
+    /**
+     * Minfication should be disabled whenever BundleConfig module is active
+     *
+     * @param \Magento\Framework\View\Asset\Minification $subject
+     * @param \Closure $proceed
+     * @param string $contentType
+     * @return bool
+     */
+    public function aroundIsEnabled(
+        \Magento\Framework\View\Asset\Minification $subject,
+        \Closure $proceed,
+        $contentType) {
+        // always disable minification for JS
+        if ($contentType === 'js') {
+            return false;
+        }
+        // proceed with normal processing for other assets
+        return $proceed($contentType);
+    }
+}

--- a/Magento_BundleConfig/Plugin/View/Asset/MinificationPlugin.php
+++ b/Magento_BundleConfig/Plugin/View/Asset/MinificationPlugin.php
@@ -1,6 +1,8 @@
 <?php
 namespace Magento\BundleConfig\Plugin\View\Asset;
 
+use Magento\Framework\View\Asset\Minification;
+
 /**
  * Class MinificationPlugin
  * @package Magento\BundleConfig\Plugin\View\Asset
@@ -10,15 +12,16 @@ class MinificationPlugin
     /**
      * Minfication should be disabled whenever BundleConfig module is active
      *
-     * @param \Magento\Framework\View\Asset\Minification $subject
+     * @param Minification $subject
      * @param \Closure $proceed
      * @param string $contentType
      * @return bool
      */
     public function aroundIsEnabled(
-        \Magento\Framework\View\Asset\Minification $subject,
+        Minification $subject,
         \Closure $proceed,
-        $contentType) {
+        $contentType
+    ) {
         // always disable minification for JS
         if ($contentType === 'js') {
             return false;

--- a/Magento_BundleConfig/etc/di.xml
+++ b/Magento_BundleConfig/etc/di.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\View\Asset\Minification">
+        <plugin name="bundle_config_minification_plugin" type="Magento\BundleConfig\Plugin\View\Asset\MinificationPlugin" />
+    </type>
+</config>


### PR DESCRIPTION
## This PR is a:

- [x] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [ ] Bugfix
- [ ] Test for existing code
- [ ] Documentation

## Summary

When this pull request is merged, it will disable minification of JS assets in core Magento code. This is done as the RequireJS optimizer needs JS files to not be minified to work correctly.
Minification of other assets will be processed as normal.

## Additional information
Related issue #47 