### PR TITLE
Allow PHP versions from 7.0.13 inline with Magento 2.2.x requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-bundle-config",
     "description": "Backend extension to the helpful in-browser debugging/inspection tools for the Magento 2 Front-End",
     "require": {
-        "php": "^7.1.0|^7.2.0",
+        "php": "^7.0.13|^7.1.0|^7.2.0",
         "magento/framework": "^100.0.20|^101.0.0|^102.0.0"
     },
     "suggest": {


### PR DESCRIPTION
## This PR is a:

- [ ] New feature
- [x] Enhancement/Optimization
- [ ] Refactor
- [ ] Bugfix
- [ ] Test for existing code
- [ ] Documentation

## Summary

When this pull request is merged, it will allow installation via composer for Magento 2.2.x instances with a PHP version < 7.1
As per https://devdocs.magento.com/guides/v2.2/install-gde/system-requirements-tech.html version 7.0.13+ is supported for Magento 2.2.x

## Additional information
