### PR TITLE
Append bundles after `requirejs-config` and `mage/requirejs/mixins`

### DIFF
--- a/Magento_BundleConfig/Block/Html/Head/Config.php
+++ b/Magento_BundleConfig/Block/Html/Head/Config.php
@@ -87,10 +87,9 @@ class Config extends \Magento\Framework\View\Element\AbstractBlock
         $sharedBundleAbsPath = $staticDir . "/" . $sharedBundleRelPath;
 
         if (file_exists($sharedBundleAbsPath)) {
-            $assetCollection->insert(
+            $assetCollection->add(
                 $sharedBundleRelPath,
-                $shared,
-                RequireJsConfig::REQUIRE_JS_FILE_NAME
+                $shared
             );
         }
 


### PR DESCRIPTION
Instead of inserting the bundles directly after `requirejs/require`, append the bundles using `add`. This causes the bundles to be loaded after 2 important files that need to be loaded before these bundles: `requirejs-config` and `mage/requirejs/mixins`.

## This PR is a:

- [ ] New feature
- [ ] Enhancement/Optimization
- [ ] Refactor
- [x] Bugfix
- [ ] Test for existing code
- [ ] Documentation

## Summary

When this pull request is merged, it will make mixins work correctly.

## Additional information

This fixes issue #57 